### PR TITLE
fix: specify build target in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 
   build: {
     outDir: 'dist',
+    target: 'esnext',
   },
 
   css: {


### PR DESCRIPTION
#### Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

---

#### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### Related issue link

n/a

#### Background and solution

Top-level await wasn't available with default vite settings. Update target property.
