### PR TITLE
fix: update api controller

### DIFF
--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -25,6 +25,10 @@ import { createProductQuery } from 'utils/create-product-query';
 
 const { PROJECT_KEY, CLIENT_SECRET, CLIENT_ID, AUTH_URL, API_URL, SCOPES } = CTP_CONFIG;
 
+interface SignInOptions {
+  isCartMerge?: boolean;
+}
+
 class ApiController {
   /* CUSTOMER */
   public async registerCustomer(
@@ -36,10 +40,15 @@ class ApiController {
       .post({ body: { ...customer, anonymousId: anonymousIdService.getAnonymousId() } })
       .execute();
 
-    return await this.signInCustomer(customer);
+    return await this.signInCustomer(customer, { isCartMerge: false });
   }
 
-  public async signInCustomer(customer: SignInType): Promise<ClientResponse<CustomerSignInResult>> {
+  public async signInCustomer(
+    customer: SignInType,
+    signInOptions: SignInOptions = (() => {
+      return { isCartMerge: true };
+    })()
+  ): Promise<ClientResponse<CustomerSignInResult>> {
     const temporaryTokenCache = new InMemoryTokenCache();
 
     const options: PasswordAuthMiddlewareOptions = {
@@ -68,10 +77,13 @@ class ApiController {
       projectKey: PROJECT_KEY,
     });
 
-    const response = await temporaryApiRoot
-      .login()
-      .post({ body: { ...customer, anonymousId: anonymousIdService.getAnonymousId() } })
-      .execute();
+    const body: SignInType & { anonymousId?: string } = customer;
+
+    if (signInOptions.isCartMerge) {
+      body.anonymousId = anonymousIdService.getAnonymousId();
+    }
+
+    const response = await temporaryApiRoot.login().post({ body }).execute();
 
     if (response.statusCode === 200) {
       const newTokenCache = temporaryTokenCache.get();


### PR DESCRIPTION
#### Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

---

#### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### Related issue link

n/a

#### Background and solution

- On initial opening of the application or opening in incognito mode (in general - if there is no token in localStorage), the api.controller.getAppData's cartResponse and discountResponse requests within Promise.all triggered a race condition, and when called simultaneously, the second caused an error. Removed Promise.all.

- When registering an anonymous user after filling the cart, an error occurred stating that the anonymousId had already been used for sign-in or sign-up. During autologin after registration, the anonymousId was repeatedly sent, even though it had already been invalidated during the registration process. Carts do not merge when no products are added, so this error does not happen when the customer just register without filling the cart. The anonymousId is not "spent" on shopping cart merging and is not invalidated. Made a distinction between a normal login and a login after registration by passing options to the signInCustomer method that serves as a flag.