### PR TITLE
fix: handle anonymous token expiration time

### DIFF
--- a/src/services/ctp-api-client.service.ts
+++ b/src/services/ctp-api-client.service.ts
@@ -62,6 +62,10 @@ class ApiRoot {
   }
 
   public root(): ByProjectKeyRequestBuilder {
+    if (this.tokenCache.get().expirationTime <= Date.now()) {
+      anonymousIdService.resetAnonymousId();
+    }
+
     if (this.tokenCache.getRefreshToken()) {
       return this.withRefreshTokenFlow();
     }


### PR DESCRIPTION
This prevents "The anonymousId is already in use" error when the anonymous session token expires.

#### Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)

---

#### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### Related issue link

n/a

#### Background and solution

One of the reasons for "The anonymousId is already in use" error occurs is when the anonymous token expires. The client attempts to renew it, sending a request, but 'anonymousId' has already been used to obtain the previous token (which has already expired) and is invalid for obtaining a new one — hence the error. This pr adds a simple functionality to reset "anonymousId" if the anonymous session token is expired when creating a request builder (root).
